### PR TITLE
Resolves #19 Keep screen on and device unlocked during reader software updates

### DIFF
--- a/Example/Example/UpdateReaderViewController.swift
+++ b/Example/Example/UpdateReaderViewController.swift
@@ -73,6 +73,7 @@ class UpdateReaderViewController: TableViewController, TerminalDelegate, UpdateR
     }
 
     private func installUpdate() {
+        UIApplication.shared.isIdleTimerDisabled = true
         installUpdateBlock?(true)
     }
 
@@ -137,6 +138,7 @@ class UpdateReaderViewController: TableViewController, TerminalDelegate, UpdateR
 
     @objc func cancelAction() {
         if installUpdateBlock != nil {
+            UIApplication.shared.isIdleTimerDisabled = false
             dismiss(animated: true, completion: nil)
         }
         else if let cancelable = updateCancelable {
@@ -147,11 +149,13 @@ class UpdateReaderViewController: TableViewController, TerminalDelegate, UpdateR
             }
         }
         else {
+            UIApplication.shared.isIdleTimerDisabled = false
             dismiss(animated: true, completion: nil)
         }
     }
 
     @objc func doneAction() {
+        UIApplication.shared.isIdleTimerDisabled = false
         dismiss(animated: true, completion: nil)
     }
 
@@ -185,6 +189,7 @@ class UpdateReaderViewController: TableViewController, TerminalDelegate, UpdateR
         updateContent()
         cancelButton?.isEnabled = false
         doneButton?.isEnabled = true
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 
 }


### PR DESCRIPTION
Resolves #19 

All of my changes are in the `UpdateReaderViewController`, where I disable the idle timer in the `installUpdate` method, and restore the idle timer in the `cancelAction` and `doneAction` methods. In both of these cases, I paired my change with the `dismiss(animated:)` call. For good measure, I also disabled the idle timer in the `didCompleteReaderSoftwareUpdate` callback.

Part of me thinks this change is simple enough that I couldn't possibly have missed anything. Part of me worries I went overboard in ensuring the default state of the `UIApplication` idle timer is restored. I'm a novice iOS dev, so I suggest careful review for anything I may have overlooked, especially if there are other areas of code that are involved in the reader updates.

I was able to successfully build the project after my changes, but didn't do extensive manual testing.