### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Please only file issues here that you believe represent actual bugs or feature requests for the Stripe Terminal iOS SDK.
+
+If you're having general trouble with your Stripe integration, please reach out to support using the form at https://support.stripe.com/ (preferred) or via email to support-terminal@stripe.com.
+
+Otherwise, to make it easier to diagnose your issue, please fill out the following:
+-->
+
+## Summary
+<!-- A simple summary of the problems you're having. -->
+
+## Code to reproduce
+<!-- If possible, please include a brief piece of code (or ideally, a link to an example project) demonstrating the problem you're having. -->
+
+## iOS version
+<!-- What version of iOS are you observing the problem on? -->
+
+## Installation method
+<!-- How did you install our SDK? -->
+
+## SDK version
+<!--
+What version of our SDK are you using? You can find this by either looking at your `Podfile.lock` (if you're using Cocoapods), your `Cartfile.resolved` (if you're using Carthage).
+ -->
+
+## Other information
+<!-- Anything else you can include that'll make it easier for us to help you! -->


### PR DESCRIPTION
Add basic issue template consistent with the current Stripe iOS SDK issue template. There's a new Github workflow for adding different templates for bugs vs. feature requests, which can contain additional contact info, but I don't have settings access to the repo so going with simple + consistent for right now.