### PR TITLE
Fix wisepos-e payment intent due to wrong naming

### DIFF
--- a/Example/Example/APIClient.swift
+++ b/Example/Example/APIClient.swift
@@ -85,7 +85,7 @@ class APIClient: NSObject, ConnectionTokenProvider {
             .responseJSON { responseJSON in
                 switch responseJSON.result {
                 case .success(let json as [String: AnyObject]):
-                    if let secret = json["secret"] as? String {
+                    if let secret = json["client_secret"] as? String {
                         completion(.success(secret))
                         return
                     }


### PR DESCRIPTION
Hi,

by default, payment intent on WisePOS E doesn't work.
It seems that field name has changed and it's now "client_secret" instead of secret.

BR,
Nicolas