### PR TITLE
SCPBlocks: fix 'occured' -> 'occurred' in doc comment

### DIFF
--- a/PublicHeaders/SCPBlocks.h
+++ b/PublicHeaders/SCPBlocks.h
@@ -60,7 +60,7 @@ typedef void (^SCPPaymentMethodCompletionBlock)(SCPPaymentMethod *__nullable pay
 /**
  A block called with an optional error.
 
- @param error       The error, or nil if no error occured.
+ @param error       The error, or nil if no error occurred.
  */
 typedef void (^SCPErrorCompletionBlock)(NSError *__nullable error)
     NS_SWIFT_NAME(ErrorCompletionBlock);


### PR DESCRIPTION
Doc comment in `PublicHeaders/SCPBlocks.h` line 63 reads `no error occured`. Fixed to `occurred`. Comment-only change.

The generated docs (`docs/`) will be regenerated from the source on next build, so fixing this header propagates to all versions of the HTML documentation.